### PR TITLE
Support real-world quirky schemas

### DIFF
--- a/examples/example_diff.rs
+++ b/examples/example_diff.rs
@@ -58,6 +58,10 @@ enum Commands {
         /// Accept invalid TLS certificates for the second database
         #[arg(long, default_value_t = false, required = false)]
         accept_invalid_certs_second_db: bool,
+        /// If a table does not have a primary key, use all columns for total ordering during
+        /// hashing
+        #[arg(long, required = false)]
+        replica_identity: String,
     },
 }
 
@@ -85,6 +89,7 @@ async fn main() -> Result<()> {
             schema_name,
             accept_invalid_certs_first_db,
             accept_invalid_certs_second_db,
+            replica_identity,
         } => {
             let payload = DiffPayload::builder()
                 .first_db(first_db.clone())
@@ -100,6 +105,7 @@ async fn main() -> Result<()> {
                 .schema_name(schema_name.clone())
                 .accept_invalid_certs_first_db(*accept_invalid_certs_first_db)
                 .accept_invalid_certs_second_db(*accept_invalid_certs_second_db)
+                .replica_identity(replica_identity.clone())
                 .build();
             let _ = Differ::diff_dbs(payload).await;
             Ok(())

--- a/rust-pgdatadiff-client/src/main.rs
+++ b/rust-pgdatadiff-client/src/main.rs
@@ -60,6 +60,9 @@ enum Commands {
         /// Accept invalid TLS certificates for the second database
         #[arg(long, default_value_t = false, required = false)]
         accept_invalid_certs_second_db: bool,
+        /// Accept invalid TLS certificates for the second database
+        #[arg(long, default_value = "default", required = false)]
+        replica_identity: String,
     },
 }
 
@@ -85,6 +88,7 @@ async fn main_clap() -> Result<()> {
             schema_name,
             accept_invalid_certs_first_db,
             accept_invalid_certs_second_db,
+            replica_identity,
         } => {
             let payload = DiffPayload::builder()
                 .first_db(first_db.clone())
@@ -100,6 +104,7 @@ async fn main_clap() -> Result<()> {
                 .schema_name(schema_name.clone())
                 .accept_invalid_certs_first_db(*accept_invalid_certs_first_db)
                 .accept_invalid_certs_second_db(*accept_invalid_certs_second_db)
+                .replica_identity(replica_identity.clone())
                 .build();
             let _ = Differ::diff_dbs(payload).await;
             Ok(())
@@ -161,6 +166,10 @@ async fn main_inquire() -> Result<()> {
         Confirm::new("Do you want to accept invalid TLS cert for second DB?")
             .with_default(false)
             .prompt()?;
+    let replica_identity_full =
+        Confirm::new("For tables without a primary key, do you want to fall back to full-table ordering, a la REPLICA IDENTITY FULL?")
+            .with_default(false)
+            .prompt()?;
 
     let payload = DiffPayload::builder()
         .first_db(first_db)
@@ -186,6 +195,7 @@ async fn main_inquire() -> Result<()> {
         .schema_name(schema_name)
         .accept_invalid_certs_first_db(accept_invalid_certs_first_db)
         .accept_invalid_certs_second_db(accept_invalid_certs_second_db)
+        .replica_identity(if replica_identity_full { "full".to_string() } else { "default".to_string() })
         .build();
 
     let _ = Differ::diff_dbs(payload).await;

--- a/src/diff/diff_payload.rs
+++ b/src/diff/diff_payload.rs
@@ -15,6 +15,7 @@ pub struct DiffPayload {
     schema_name: String,
     accept_invalid_certs_first_db: bool,
     accept_invalid_certs_second_db: bool,
+    replica_identity: String,
 }
 
 #[bon]
@@ -53,6 +54,7 @@ impl DiffPayload {
         schema_name: impl Into<String>,
         accept_invalid_certs_first_db: bool,
         accept_invalid_certs_second_db: bool,
+        replica_identity: String,
     ) -> Self {
         let has_included_tables = !include_tables.is_empty();
         let has_excluded_tables = !exclude_tables.is_empty();
@@ -75,6 +77,7 @@ impl DiffPayload {
             schema_name: schema_name.into(),
             accept_invalid_certs_first_db,
             accept_invalid_certs_second_db,
+            replica_identity,
         }
     }
 
@@ -119,6 +122,9 @@ impl DiffPayload {
     }
     pub fn any_accept_invalid_certs(&self) -> bool {
         self.accept_invalid_certs_first_db || self.accept_invalid_certs_second_db
+    }
+    pub fn replica_identity(&self) -> &str {
+        &self.replica_identity
     }
 }
 

--- a/src/diff/table/query/input/mod.rs
+++ b/src/diff/table/query/input/mod.rs
@@ -109,12 +109,17 @@ impl QueryHashDataInput {
 
 /// Represents the input for querying primary keys.
 pub struct QueryPrimaryKeysInput {
+    table_schema: String,
     table_name: String,
 }
 
 impl QueryPrimaryKeysInput {
-    pub fn new(table_name: String) -> Self {
-        Self { table_name }
+    pub fn new(table_schema: String, table_name: String) -> Self {
+        Self { table_schema, table_name }
+    }
+
+    pub fn table_schema(&self) -> String {
+        self.table_schema.to_string()
     }
 
     pub fn table_name(&self) -> String {

--- a/src/diff/table/query/input/mod.rs
+++ b/src/diff/table/query/input/mod.rs
@@ -1,4 +1,4 @@
-use super::table_types::{TableName, TableOffset, TablePosition, TablePrimaryKeys};
+use super::table_types::{TableName, TableOffset, TablePosition, TablePrimaryKeys, TableColumns};
 use crate::diff::types::SchemaName;
 
 /// Represents the input for querying the count of a table.
@@ -64,6 +64,7 @@ pub struct QueryHashDataInput {
     schema_name: SchemaName,
     table_name: TableName,
     primary_keys: TablePrimaryKeys,
+    table_columns: TableColumns,
     position: TablePosition,
     offset: TableOffset,
 }
@@ -74,6 +75,7 @@ impl QueryHashDataInput {
         schema_name: SchemaName,
         table_name: TableName,
         primary_keys: TablePrimaryKeys,
+        table_columns: TableColumns,
         position: TablePosition,
         offset: TableOffset,
     ) -> Self {
@@ -81,6 +83,7 @@ impl QueryHashDataInput {
             schema_name,
             table_name,
             primary_keys,
+            table_columns,
             position,
             offset,
         }
@@ -96,6 +99,10 @@ impl QueryHashDataInput {
 
     pub fn primary_keys(&self) -> TablePrimaryKeys {
         self.primary_keys.clone()
+    }
+
+    pub fn table_columns(&self) -> TableColumns {
+        self.table_columns.clone()
     }
 
     pub fn position(&self) -> TablePosition {
@@ -124,5 +131,26 @@ impl QueryPrimaryKeysInput {
 
     pub fn table_name(&self) -> String {
         self.table_name.to_string()
+    }
+}
+
+
+/// Represents the input for querying table columns.
+pub struct QueryTableColumnsInput {
+    table_schema: String,
+    table_name: String,
+}
+
+impl QueryTableColumnsInput {
+    pub fn new(table_schema: String, table_name: String) -> Self {
+        Self { table_schema, table_name }
+    }
+
+    pub fn table_name(&self) -> String {
+        self.table_name.to_string()
+    }
+
+    pub fn table_schema(&self) -> String {
+        self.table_schema.to_string()
     }
 }

--- a/src/diff/table/query/table_query.rs
+++ b/src/diff/table/query/table_query.rs
@@ -93,13 +93,13 @@ impl Display for TableQuery {
                     FROM (
                         SELECT *
                         FROM "{}"."{}"
-                        ORDER BY "{}" limit {} offset {}
+                        ORDER BY {} limit {} offset {}
                     ) AS t
                     "#,
-                    table_columns.render(table_name.name()),
+                    table_columns.render("t"),
                     schema_name.name(),
                     table_name.name(),
-                    table_primary_keys.keys(),
+                    table_primary_keys.render(table_name.name()),
                     table_offset.offset(),
                     table_position.position(),
                 )
@@ -175,7 +175,7 @@ mod tests {
     fn test_display_hash_query() {
         let schema_name = SchemaName::new("public".to_string());
         let table_name = TableName::new("table1".to_string());
-        let table_primary_keys = TablePrimaryKeys::new("id".to_string());
+        let table_primary_keys = TablePrimaryKeys::new(vec!["id".to_string()]);
         let table_columns = TableColumns::new(vec!["id".to_string()]);
         let table_position = TablePosition::new(0);
         let table_offset = TableOffset::new(100);

--- a/src/diff/table/query/table_query.rs
+++ b/src/diff/table/query/table_query.rs
@@ -45,7 +45,7 @@ impl Display for TableQuery {
             TableQuery::CountRowsForTable(schema_name, table_name) => {
                 write!(
                     f,
-                    "SELECT count(*) FROM {}.{}",
+                    "SELECT count(*) FROM {}.\"{}\"",
                     schema_name.name(),
                     table_name.name()
                 )
@@ -58,9 +58,9 @@ impl Display for TableQuery {
                 FROM   pg_index i
                 JOIN   pg_attribute a ON a.attrelid = i.indrelid
                                      AND a.attnum = ANY(i.indkey)
-                WHERE  i.indrelid = '{}'::regclass
+                WHERE  i.indrelid = '"{}"'::regclass
                 AND    i.indisprimary"#,
-                table_name.name()
+                table_name.name()  // TODO: Missing schema in the above, should be "{}"."{}"
             ),
             TableQuery::HashQuery(
                 schema_name,
@@ -75,8 +75,8 @@ impl Display for TableQuery {
                     SELECT md5(array_agg(md5((t.*)::varchar))::varchar)
                     FROM (
                         SELECT *
-                        FROM {}.{}
-                        ORDER BY {} limit {} offset {}
+                        FROM "{}"."{}"
+                        ORDER BY "{}" limit {} offset {}
                     ) AS t
                     "#,
                     schema_name.name(),

--- a/src/diff/table/query/table_query.rs
+++ b/src/diff/table/query/table_query.rs
@@ -1,5 +1,5 @@
 use crate::diff::table::query::table_types::{
-    IncludedExcludedTables, TableMode, TableName, TableOffset, TablePosition, TablePrimaryKeys,
+    IncludedExcludedTables, TableMode, TableName, TableOffset, TablePosition, TablePrimaryKeys, TableColumns,
 };
 use crate::diff::types::SchemaName;
 use std::fmt::Display;
@@ -8,10 +8,12 @@ pub enum TableQuery {
     AllTablesForSchema(SchemaName, IncludedExcludedTables),
     CountRowsForTable(SchemaName, TableName),
     FindPrimaryKeyForTable(SchemaName, TableName),
+    FindColumnsForTable(SchemaName, TableName),
     HashQuery(
         SchemaName,
         TableName,
         TablePrimaryKeys,
+        TableColumns,
         TablePosition,
         TableOffset,
     ),
@@ -63,23 +65,38 @@ impl Display for TableQuery {
                 schema_name.name(),
                 table_name.name()
             ),
+            TableQuery::FindColumnsForTable(schema_name, table_name) => write!(
+                f,
+                // language=postgresql
+                r#"
+                SELECT cs.column_name
+                FROM information_schema.columns cs
+                WHERE table_schema = '{}'
+                AND table_name = '{}'
+                ORDER BY column_name
+                "#,
+                schema_name.name(),
+                table_name.name()
+            ),
             TableQuery::HashQuery(
                 schema_name,
                 table_name,
                 table_primary_keys,
+                table_columns,
                 table_position,
                 table_offset,
             ) => {
                 write!(
                     f,
                     r#"
-                    SELECT md5(array_agg(md5((t.*)::varchar))::varchar)
+                    SELECT md5(array_agg(md5(({})::varchar))::varchar)
                     FROM (
                         SELECT *
                         FROM "{}"."{}"
                         ORDER BY "{}" limit {} offset {}
                     ) AS t
                     "#,
+                    table_columns.render(table_name.name()),
                     schema_name.name(),
                     table_name.name(),
                     table_primary_keys.keys(),
@@ -135,7 +152,7 @@ mod tests {
         let schema_name = SchemaName::new("public".to_string());
         let table_name = TableName::new("table1".to_string());
         let query = TableQuery::CountRowsForTable(schema_name, table_name);
-        let expected = "SELECT count(*) FROM public.table1";
+        let expected = "SELECT count(*) FROM public.\"table1\"";
         assert_eq!(expected, query.to_string());
     }
 
@@ -149,7 +166,7 @@ mod tests {
                 FROM   pg_index i
                 JOIN   pg_attribute a ON a.attrelid = i.indrelid
                                      AND a.attnum = ANY(i.indkey)
-                WHERE  i.indrelid = 'table1'::regclass
+                WHERE  i.indrelid = '"public"."table1"'::regclass
                 AND    i.indisprimary"#;
         assert_eq!(expected, query.to_string());
     }
@@ -159,21 +176,23 @@ mod tests {
         let schema_name = SchemaName::new("public".to_string());
         let table_name = TableName::new("table1".to_string());
         let table_primary_keys = TablePrimaryKeys::new("id".to_string());
+        let table_columns = TableColumns::new(vec!["id".to_string()]);
         let table_position = TablePosition::new(0);
         let table_offset = TableOffset::new(100);
         let query = TableQuery::HashQuery(
             schema_name,
             table_name,
             table_primary_keys,
+            table_columns,
             table_position,
             table_offset,
         );
         let expected = r#"
-                    SELECT md5(array_agg(md5((t.*)::varchar))::varchar)
+                    SELECT md5(array_agg(md5(("table1"."id")::varchar))::varchar)
                     FROM (
                         SELECT *
-                        FROM public.table1
-                        ORDER BY id limit 100 offset 0
+                        FROM "public"."table1"
+                        ORDER BY "id" limit 100 offset 0
                     ) AS t
                     "#;
         assert_eq!(expected, query.to_string());

--- a/src/diff/table/query/table_query.rs
+++ b/src/diff/table/query/table_query.rs
@@ -7,7 +7,7 @@ use std::fmt::Display;
 pub enum TableQuery {
     AllTablesForSchema(SchemaName, IncludedExcludedTables),
     CountRowsForTable(SchemaName, TableName),
-    FindPrimaryKeyForTable(TableName),
+    FindPrimaryKeyForTable(SchemaName, TableName),
     HashQuery(
         SchemaName,
         TableName,
@@ -50,7 +50,7 @@ impl Display for TableQuery {
                     table_name.name()
                 )
             }
-            TableQuery::FindPrimaryKeyForTable(table_name) => write!(
+            TableQuery::FindPrimaryKeyForTable(schema_name, table_name) => write!(
                 f,
                 // language=postgresql
                 r#"
@@ -58,9 +58,10 @@ impl Display for TableQuery {
                 FROM   pg_index i
                 JOIN   pg_attribute a ON a.attrelid = i.indrelid
                                      AND a.attnum = ANY(i.indkey)
-                WHERE  i.indrelid = '"{}"'::regclass
+                WHERE  i.indrelid = '"{}"."{}"'::regclass
                 AND    i.indisprimary"#,
-                table_name.name()  // TODO: Missing schema in the above, should be "{}"."{}"
+                schema_name.name(),
+                table_name.name()
             ),
             TableQuery::HashQuery(
                 schema_name,
@@ -140,8 +141,9 @@ mod tests {
 
     #[test]
     fn test_display_find_primary_key_for_table() {
+        let table_schema = SchemaName::new("public".to_string());
         let table_name = TableName::new("table1".to_string());
-        let query = TableQuery::FindPrimaryKeyForTable(table_name);
+        let query = TableQuery::FindPrimaryKeyForTable(table_schema, table_name);
         let expected = r#"
                 SELECT a.attname
                 FROM   pg_index i

--- a/src/diff/table/query/table_query_executor.rs
+++ b/src/diff/table/query/table_query_executor.rs
@@ -69,7 +69,7 @@ use async_trait::async_trait;
 use deadpool_postgres::Pool;
 
 use crate::diff::table::query::input::{
-    QueryHashDataInput, QueryPrimaryKeysInput, QueryTableCountInput, QueryTableNamesInput,
+    QueryHashDataInput, QueryPrimaryKeysInput, QueryTableColumnsInput, QueryTableCountInput, QueryTableNamesInput
 };
 use crate::diff::table::query::table_query::TableQuery;
 use crate::diff::table::query::table_types::{IncludedExcludedTables, TableName};
@@ -103,6 +103,8 @@ pub trait TableSingleSourceQueryExecutor {
     ///
     /// A vector of primary key column names.
     async fn query_primary_keys(&self, input: QueryPrimaryKeysInput) -> Vec<String>;
+
+    async fn query_table_columns(&self, input: QueryTableColumnsInput) -> Vec<String>;
 }
 
 pub struct TableSingleSourceQueryExecutorImpl {
@@ -158,6 +160,27 @@ impl TableSingleSourceQueryExecutor for TableSingleSourceQueryExecutorImpl {
         query_result
             .iter()
             .map(|row| row.get("attname"))
+            .collect::<Vec<String>>()
+    }
+
+    async fn query_table_columns(&self, input: QueryTableColumnsInput) -> Vec<String> {
+        // Acquire the database client
+        let client = self.db_pool.get().await.unwrap();
+
+        // Prepare the query for primary keys fetching
+        let find_columns_query =
+            TableQuery::FindColumnsForTable(SchemaName::new(input.table_schema()), TableName::new(input.table_name()));
+
+        // Fetch primary keys for the table
+        let query_result = client
+            .query(&find_columns_query.to_string(), &[])
+            .await
+            .unwrap();
+
+        // Map query results to [Vec<String>]
+        query_result
+            .iter()
+            .map(|row| row.get("column_name"))
             .collect::<Vec<String>>()
     }
 }
@@ -252,6 +275,7 @@ impl TableDualSourceQueryExecutor for TableDualSourceQueryExecutorImpl {
             input.schema_name(),
             input.table_name(),
             input.primary_keys(),
+            input.table_columns(),
             input.position(),
             input.offset(),
         );

--- a/src/diff/table/query/table_query_executor.rs
+++ b/src/diff/table/query/table_query_executor.rs
@@ -73,6 +73,7 @@ use crate::diff::table::query::input::{
 };
 use crate::diff::table::query::table_query::TableQuery;
 use crate::diff::table::query::table_types::{IncludedExcludedTables, TableName};
+use crate::diff::types::SchemaName;
 
 #[cfg(test)]
 use mockall::automock;
@@ -145,7 +146,7 @@ impl TableSingleSourceQueryExecutor for TableSingleSourceQueryExecutorImpl {
 
         // Prepare the query for primary keys fetching
         let find_primary_key_query =
-            TableQuery::FindPrimaryKeyForTable(TableName::new(input.table_name()));
+            TableQuery::FindPrimaryKeyForTable(SchemaName::new(input.table_schema()), TableName::new(input.table_name()));
 
         // Fetch primary keys for the table
         let query_result = client

--- a/src/diff/table/query/table_types.rs
+++ b/src/diff/table/query/table_types.rs
@@ -25,6 +25,24 @@ impl TablePrimaryKeys {
 }
 
 #[derive(Clone)]
+pub struct TableColumns(Vec<String>);
+
+impl TableColumns {
+    pub fn new(keys: impl Into<Vec<String>>) -> Self {
+        Self(keys.into())
+    }
+
+    pub fn render(&self, table_binding: &str) -> String {
+        self.0
+            .iter()
+            .map(|col| format!("\"{table_binding}\".\"{}\"", col))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+
+#[derive(Clone)]
 pub struct TablePosition(i64);
 
 impl TablePosition {

--- a/src/diff/table/query/table_types.rs
+++ b/src/diff/table/query/table_types.rs
@@ -12,15 +12,19 @@ impl TableName {
 }
 
 #[derive(Clone)]
-pub struct TablePrimaryKeys(String);
+pub struct TablePrimaryKeys(Vec<String>);
 
 impl TablePrimaryKeys {
-    pub fn new(keys: impl Into<String>) -> Self {
+    pub fn new(keys: impl Into<Vec<String>>) -> Self {
         Self(keys.into())
     }
 
-    pub fn keys(&self) -> &str {
-        &self.0
+    pub fn render(&self, table_binding: &str) -> String {
+        self.0
+            .iter()
+            .map(|col| format!("\"{table_binding}\".\"{}\"", col))
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 }
 

--- a/src/diff/table/table_differ.rs
+++ b/src/diff/table/table_differ.rs
@@ -92,7 +92,7 @@ impl<TQE: TableSingleSourceQueryExecutor, DTQE: TableDualSourceQueryExecutor>
                 return table_diff_result;
             }
 
-            let query_primary_keys_input = QueryPrimaryKeysInput::new(table_name.clone());
+            let query_primary_keys_input = QueryPrimaryKeysInput::new(diff_payload.schema_name().to_string(), table_name.clone());
 
             let primary_keys = self
                 .single_table_query_executor

--- a/src/diff/table/table_differ.rs
+++ b/src/diff/table/table_differ.rs
@@ -92,6 +92,13 @@ impl<TQE: TableSingleSourceQueryExecutor, DTQE: TableDualSourceQueryExecutor>
                 return table_diff_result;
             }
 
+            let query_table_columns_input = QueryTableColumnsInput::new(diff_payload.schema_name().to_string(), table_name.clone());
+
+            let columns = self
+                .single_table_query_executor
+                .query_table_columns(query_table_columns_input)
+                .await;
+
             let query_primary_keys_input = QueryPrimaryKeysInput::new(diff_payload.schema_name().to_string(), table_name.clone());
 
             let primary_keys = self
@@ -99,18 +106,17 @@ impl<TQE: TableSingleSourceQueryExecutor, DTQE: TableDualSourceQueryExecutor>
                 .query_primary_keys(query_primary_keys_input)
                 .await;
 
+            let primary_keys = if primary_keys.is_empty() && diff_payload.replica_identity() == "full" {
+                columns.clone()
+            } else {
+                primary_keys
+            };
+
             // If no primary keys found, return the result
             if primary_keys.is_empty() {
                 let table_diff_result = TableDiffOutput::NoPrimaryKeyFound(table_name.clone());
                 return table_diff_result;
             }
-
-            let query_table_columns_input = QueryTableColumnsInput::new(diff_payload.schema_name().to_string(), table_name.clone());
-
-            let columns = self
-                .single_table_query_executor
-                .query_table_columns(query_table_columns_input)
-                .await;
 
             let total_rows = match table_diff_result {
                 TableDiffOutput::NoCountDiff(_, rows) => rows,

--- a/src/diff/table/table_differ.rs
+++ b/src/diff/table/table_differ.rs
@@ -1,6 +1,6 @@
 use crate::diff::diff_payload::DiffPayload;
 use crate::diff::table::query::input::{
-    QueryHashDataInput, QueryPrimaryKeysInput, QueryTableCountInput, QueryTableNamesInput,
+    QueryHashDataInput, QueryPrimaryKeysInput, QueryTableColumnsInput, QueryTableCountInput, QueryTableNamesInput
 };
 use crate::diff::table::query::output::{TableCountDiff, TableDiffOutput, TableSource};
 
@@ -8,7 +8,7 @@ use crate::diff::table::query::table_query_executor::{
     TableDualSourceQueryExecutor, TableSingleSourceQueryExecutor,
 };
 use crate::diff::table::query::table_types::{
-    TableName, TableOffset, TablePosition, TablePrimaryKeys,
+    TableColumns, TableName, TableOffset, TablePosition, TablePrimaryKeys
 };
 use anyhow::Result;
 use colored::Colorize;
@@ -109,6 +109,13 @@ impl<TQE: TableSingleSourceQueryExecutor, DTQE: TableDualSourceQueryExecutor>
             // Will be used for query ordering when hashing data
             let primary_keys = primary_keys.as_slice().join(",");
 
+            let query_table_columns_input = QueryTableColumnsInput::new(diff_payload.schema_name().to_string(), table_name.clone());
+
+            let columns = self
+                .single_table_query_executor
+                .query_table_columns(query_table_columns_input)
+                .await;
+
             let total_rows = match table_diff_result {
                 TableDiffOutput::NoCountDiff(_, rows) => rows,
                 _ => {
@@ -121,6 +128,7 @@ impl<TQE: TableSingleSourceQueryExecutor, DTQE: TableDualSourceQueryExecutor>
             let query_table_name = TableName::new(table_name.clone());
             let table_offset = TableOffset::new(diff_payload.chunk_size());
             let table_primary_keys = TablePrimaryKeys::new(primary_keys);
+            let table_columns = TableColumns::new(columns);
 
             let start = Instant::now();
 
@@ -131,6 +139,7 @@ impl<TQE: TableSingleSourceQueryExecutor, DTQE: TableDualSourceQueryExecutor>
                     query_table_name,
                     table_offset,
                     table_primary_keys,
+                    table_columns,
                     total_rows,
                     start,
                 )
@@ -225,6 +234,7 @@ impl<TQE: TableSingleSourceQueryExecutor, DTQE: TableDualSourceQueryExecutor>
         query_table_name: TableName,
         table_offset: TableOffset,
         table_primary_keys: TablePrimaryKeys,
+        table_columns: TableColumns,
         total_rows: i64,
         start: Instant,
     ) -> Option<TableDiffOutput> {
@@ -235,6 +245,7 @@ impl<TQE: TableSingleSourceQueryExecutor, DTQE: TableDualSourceQueryExecutor>
                 schema_name.clone(),
                 query_table_name.clone(),
                 table_primary_keys.clone(),
+                table_columns.clone(),
                 TablePosition::new(position),
                 table_offset.clone(),
             );

--- a/src/diff/table/table_differ.rs
+++ b/src/diff/table/table_differ.rs
@@ -105,10 +105,6 @@ impl<TQE: TableSingleSourceQueryExecutor, DTQE: TableDualSourceQueryExecutor>
                 return table_diff_result;
             }
 
-            // Prepare the primary keys for the table
-            // Will be used for query ordering when hashing data
-            let primary_keys = primary_keys.as_slice().join(",");
-
             let query_table_columns_input = QueryTableColumnsInput::new(diff_payload.schema_name().to_string(), table_name.clone());
 
             let columns = self

--- a/src/diff/table/table_differ_tests.rs
+++ b/src/diff/table/table_differ_tests.rs
@@ -129,6 +129,11 @@ mod tests {
             .times(1)
             .returning(|_| vec!["id".to_string()]);
 
+        single_source_query_executor
+            .expect_query_table_columns()
+            .times(1)
+            .returning(|_| vec!["id".to_string()]);
+
         dual_source_query_executor
             .expect_query_hash_data()
             .times(1)


### PR DESCRIPTION
Hello, thank you for the tool! I offer this PR after running into some issues using your tool against our schema; it was fairly easy to modify, even without knowing about the organization of the codebase, what I initially lamented as boilerplate was actually helping guide me exactly to the implementation I wanted -- really, really good work.

Features added:

- Missing quotes strips load-bearing case sensitivity
  Prisma, when left to its own devices, will name tables and columns without any consideration to ergonomics.
  
  eg: `User` has a column `enrichmentProfileExecutedAt`...
  ...which when unquoted get normalized into `user.enrichmentprofileexecutedat`...
  which are not found.

- "Squashed" schema migrations are susceptible to columns being out of order.
  Due to some infrastructure challenges trying to bridge the gap between CNPG and RDS, I was unable to use DDL replication, and had to resort to applying prisma migrations to bootstrap prior to starting replication.

  Unfortunately, this meant that my db1 and db2 had columns that were out of order, leading to `t.*` being different and the resultant hashes being incorrect.
  After adding a new query to select columns and order them explicitly, now validation checks pass with no problems.

- Finally, we have a few tables without primary keys. This is regrettable, and I would totally understand if this is a bridge too far, but in order to get logical replication set up I had to `ALTER TABLE public."..." REPLICA IDENTITY FULL`.

  In the same vein, I added `--replica-identity full` as a fallback strategy to work around `No primary key found`

In a perfect world we wouldn't need tools like pgdatadiff, but today I was tremendously grateful for it being available. Thank you!